### PR TITLE
ExpectaSupport: pass object by pointer instead of vararg.

### DIFF
--- a/Expecta/ExpectaObject.h
+++ b/Expecta/ExpectaObject.h
@@ -1,6 +1,10 @@
 #import <Foundation/Foundation.h>
 
-#define EXPObjectify(value) _EXPObjectify(@encode(__typeof__((value))), (value))
+#define EXPObjectify(value) \
+  ({ \
+    __typeof__((value)) _local = (value); \
+    _EXPObjectify(@encode(__typeof__((value))), (void *)&_local); \
+  })
 #define EXP_expect(actual) _EXP_expect(self, __LINE__, __FILE__, ^id{ __typeof__((actual)) strongActual = (actual); return EXPObjectify(strongActual); })
 #define EXPMatcherInterface(matcherName, matcherArguments) _EXPMatcherInterface(matcherName, matcherArguments)
 #define EXPMatcherImplementationBegin(matcherName, matcherArguments) _EXPMatcherImplementationBegin(matcherName, matcherArguments)

--- a/Expecta/ExpectaSupport.h
+++ b/Expecta/ExpectaSupport.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-id _EXPObjectify(const char *type, ...);
+id _EXPObjectify(const char *type, void *value);
 EXPExpect *_EXP_expect(id testCase, int lineNumber, const char *fileName, EXPIdBlock actualBlock);
 
 void EXPFail(id testCase, int lineNumber, const char *fileName, NSString *message);


### PR DESCRIPTION
The whole point of passing a _single_ object via `vararg` seems
redundant and risky, since there are default argument promotions in
effect which may change the input value. In particular, the address
sanitizer complained about passing a struct with three floats and
claimed that accessing the vararg causing out of memory access.

Since it's unclear whether calling `va_arg` on a struct is even
well-defined, I chose to drop vararg handling completely and use a
`void *` instead.

Additionally, I used `NSGetSizeAndAlignment` to make the floating point
struct handling more robust.

In general, I believe that most of the code in this method can be
reduced to a single `[NSValue valueWithBytes:objCType:]` call, but
that's out of the scope of this commit.