### PR TITLE
Expecta: pass actual to block matchers.

### DIFF
--- a/Expecta/EXPBlockDefinedMatcher.h
+++ b/Expecta/EXPBlockDefinedMatcher.h
@@ -10,16 +10,19 @@
 #import "EXPMatcher.h"
 #import "EXPDefines.h"
 
+typedef BOOL (^EXPMatchBlock)(id actual);
+typedef NSString *(^EXPFailureMessageBlock)(id actual);
+
 @interface EXPBlockDefinedMatcher : NSObject <EXPMatcher> {
-  EXPBoolBlock prerequisiteBlock;
-  EXPBoolBlock matchBlock;
-  EXPStringBlock failureMessageForToBlock;
-  EXPStringBlock failureMessageForNotToBlock;
+  EXPMatchBlock prerequisiteBlock;
+  EXPMatchBlock matchBlock;
+  EXPFailureMessageBlock failureMessageForToBlock;
+  EXPFailureMessageBlock failureMessageForNotToBlock;
 }
 
-@property(nonatomic, copy) EXPBoolBlock prerequisiteBlock;
-@property(nonatomic, copy) EXPBoolBlock matchBlock;
-@property(nonatomic, copy) EXPStringBlock failureMessageForToBlock;
-@property(nonatomic, copy) EXPStringBlock failureMessageForNotToBlock;
+@property(nonatomic, copy) EXPMatchBlock prerequisiteBlock;
+@property(nonatomic, copy) EXPMatchBlock matchBlock;
+@property(nonatomic, copy) EXPFailureMessageBlock failureMessageForToBlock;
+@property(nonatomic, copy) EXPFailureMessageBlock failureMessageForNotToBlock;
 
 @end

--- a/Expecta/EXPBlockDefinedMatcher.m
+++ b/Expecta/EXPBlockDefinedMatcher.m
@@ -28,7 +28,7 @@
 - (BOOL)meetsPrerequesiteFor:(id)actual
 {
   if (self.prerequisiteBlock) {
-    return self.prerequisiteBlock();
+    return self.prerequisiteBlock(actual);
   }
   return YES;
 }
@@ -36,7 +36,7 @@
 - (BOOL)matches:(id)actual
 {
   if (self.matchBlock) {
-    return self.matchBlock();
+    return self.matchBlock(actual);
   }
   return YES;
 }
@@ -44,7 +44,7 @@
 - (NSString *)failureMessageForTo:(id)actual
 {
   if (self.failureMessageForToBlock) {
-    return self.failureMessageForToBlock();
+    return self.failureMessageForToBlock(actual);
   }
   return nil;
 }
@@ -52,7 +52,7 @@
 - (NSString *)failureMessageForNotTo:(id)actual
 {
   if (self.failureMessageForNotToBlock) {
-    return self.failureMessageForNotToBlock();
+    return self.failureMessageForNotToBlock(actual);
   }
   return nil;
 }

--- a/Expecta/EXPDefines.h
+++ b/Expecta/EXPDefines.h
@@ -11,7 +11,5 @@
 
 typedef void (^EXPBasicBlock)(void);
 typedef id (^EXPIdBlock)(void);
-typedef BOOL (^EXPBoolBlock)(void);
-typedef NSString *(^EXPStringBlock)(void);
 
 #endif

--- a/Expecta/EXPExpect.h
+++ b/Expecta/EXPExpect.h
@@ -33,7 +33,6 @@
 + (EXPExpect *)expectWithActualBlock:(id)actualBlock testCase:(id)testCase lineNumber:(int)lineNumber fileName:(const char *)fileName;
 
 - (void)applyMatcher:(id<EXPMatcher>)matcher;
-- (void)applyMatcher:(id<EXPMatcher>)matcher to:(NSObject **)actual;
 
 @end
 

--- a/Expecta/EXPExpect.m
+++ b/Expecta/EXPExpect.m
@@ -102,51 +102,47 @@
   return nil;
 }
 
-- (void)applyMatcher:(id<EXPMatcher>)matcher
-{
-  id actual = [self actual];
-  [self applyMatcher:matcher to:&actual];
-}
-
-- (void)applyMatcher:(id<EXPMatcher>)matcher to:(NSObject **)actual {
-  if([*actual isKindOfClass:[EXPUnsupportedObject class]]) {
+- (void)applyMatcher:(id<EXPMatcher>)matcher {
+  id actual = self.actual;
+  
+  if([actual isKindOfClass:[EXPUnsupportedObject class]]) {
     EXPFail(self.testCase, self.lineNumber, self.fileName,
-            [NSString stringWithFormat:@"expecting a %@ is not supported", ((EXPUnsupportedObject *)*actual).type]);
+            [NSString stringWithFormat:@"expecting a %@ is not supported", ((EXPUnsupportedObject *)actual).type]);
   } else {
     BOOL failed = NO;
-    if([matcher respondsToSelector:@selector(meetsPrerequesiteFor:)] &&
-       ![matcher meetsPrerequesiteFor:*actual]) {
+    if ([matcher respondsToSelector:@selector(meetsPrerequesiteFor:)] &&
+        ![matcher meetsPrerequesiteFor:actual]) {
       failed = YES;
     } else {
       BOOL matchResult = NO;
-      if(self.asynchronous) {
+      if (self.asynchronous) {
         NSTimeInterval timeOut = self.timeout;
         NSDate *expiryDate = [NSDate dateWithTimeIntervalSinceNow:timeOut];
         while(1) {
-          matchResult = [matcher matches:*actual];
+          matchResult = [matcher matches:actual];
           failed = self.negative ? matchResult : !matchResult;
           if(!failed || ([(NSDate *)[NSDate date] compare:expiryDate] == NSOrderedDescending)) {
             break;
           }
           [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
           OSMemoryBarrier();
-          *actual = self.actual;
+          actual = self.actual;
         }
       } else {
-        matchResult = [matcher matches:*actual];
+        matchResult = [matcher matches:actual];
       }
       failed = self.negative ? matchResult : !matchResult;
     }
-    if(failed) {
+    if (failed) {
       NSString *message = nil;
 
       if(self.negative) {
         if ([matcher respondsToSelector:@selector(failureMessageForNotTo:)]) {
-          message = [matcher failureMessageForNotTo:*actual];
+          message = [matcher failureMessageForNotTo:actual];
         }
       } else {
         if ([matcher respondsToSelector:@selector(failureMessageForTo:)]) {
-          message = [matcher failureMessageForTo:*actual];
+          message = [matcher failureMessageForTo:actual];
         }
       }
       if (message == nil) {

--- a/Expecta/ExpectaSupport.h
+++ b/Expecta/ExpectaSupport.h
@@ -11,10 +11,10 @@ EXPExpect *_EXP_expect(id testCase, int lineNumber, const char *fileName, EXPIdB
 void EXPFail(id testCase, int lineNumber, const char *fileName, NSString *message);
 NSString *EXPDescribeObject(id obj);
 
-void EXP_prerequisite(EXPBoolBlock block);
-void EXP_match(EXPBoolBlock block);
-void EXP_failureMessageForTo(EXPStringBlock block);
-void EXP_failureMessageForNotTo(EXPStringBlock block);
+void EXP_prerequisite(EXPMatchBlock block);
+void EXP_match(EXPMatchBlock block);
+void EXP_failureMessageForTo(EXPFailureMessageBlock block);
+void EXP_failureMessageForNotTo(EXPFailureMessageBlock block);
 
 #if __has_feature(objc_arc)
 #define _EXP_release(x)
@@ -41,18 +41,17 @@ EXPFixCategoriesBug(EXPMatcher##matcherName##Matcher); \
 - (void(^) matcherArguments) matcherName { \
   EXPBlockDefinedMatcher *matcher = [[EXPBlockDefinedMatcher alloc] init]; \
   [[[NSThread currentThread] threadDictionary] setObject:matcher forKey:@"EXP_currentMatcher"]; \
-  __block id actual = self.actual; \
-  __block void (^prerequisite)(EXPBoolBlock block) = ^(EXPBoolBlock block) { EXP_prerequisite(block); }; \
-  __block void (^match)(EXPBoolBlock block) = ^(EXPBoolBlock block) { EXP_match(block); }; \
-  __block void (^failureMessageForTo)(EXPStringBlock block) = ^(EXPStringBlock block) { EXP_failureMessageForTo(block); }; \
-  __block void (^failureMessageForNotTo)(EXPStringBlock block) = ^(EXPStringBlock block) { EXP_failureMessageForNotTo(block); }; \
+  __block void (^prerequisite)(EXPMatchBlock block) = ^(EXPMatchBlock block) { EXP_prerequisite(block); }; \
+  __block void (^match)(EXPMatchBlock block) = ^(EXPMatchBlock block) { EXP_match(block); }; \
+  __block void (^failureMessageForTo)(EXPFailureMessageBlock block) = ^(EXPFailureMessageBlock block) { EXP_failureMessageForTo(block); }; \
+  __block void (^failureMessageForNotTo)(EXPFailureMessageBlock block) = ^(EXPFailureMessageBlock block) { EXP_failureMessageForNotTo(block); }; \
   prerequisite(nil); match(nil); failureMessageForTo(nil); failureMessageForNotTo(nil); \
   void (^matcherBlock) matcherArguments = [^ matcherArguments { \
     {
 
 #define _EXPMatcherImplementationEnd \
     } \
-    [self applyMatcher:matcher to:&actual]; \
+    [self applyMatcher:matcher]; \
     [[[NSThread currentThread] threadDictionary] removeObjectForKey:@"EXP_currentMatcher"]; \
   } copy]; \
   _EXP_release(matcher); \

--- a/Expecta/ExpectaSupport.m
+++ b/Expecta/ExpectaSupport.m
@@ -141,19 +141,19 @@ NSString *EXPDescribeObject(id obj) {
   return description;
 }
 
-void EXP_prerequisite(EXPBoolBlock block) {
+void EXP_prerequisite(EXPMatchBlock block) {
   [[[NSThread currentThread] threadDictionary][@"EXP_currentMatcher"] setPrerequisiteBlock:block];
 }
 
-void EXP_match(EXPBoolBlock block) {
+void EXP_match(EXPMatchBlock block) {
   [[[NSThread currentThread] threadDictionary][@"EXP_currentMatcher"] setMatchBlock:block];
 }
 
-void EXP_failureMessageForTo(EXPStringBlock block) {
+void EXP_failureMessageForTo(EXPFailureMessageBlock block) {
   [[[NSThread currentThread] threadDictionary][@"EXP_currentMatcher"] setFailureMessageForToBlock:block];
 }
 
-void EXP_failureMessageForNotTo(EXPStringBlock block) {
+void EXP_failureMessageForNotTo(EXPFailureMessageBlock block) {
   [[[NSThread currentThread] threadDictionary][@"EXP_currentMatcher"] setFailureMessageForNotToBlock:block];
 }
 

--- a/Expecta/Matchers/EXPMatchers+beCloseTo.m
+++ b/Expecta/Matchers/EXPMatchers+beCloseTo.m
@@ -2,13 +2,13 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(_beCloseToWithin, (id expected, id within)) {
-  prerequisite(^BOOL{
+  prerequisite(^BOOL(id actual) {
     return [actual isKindOfClass:[NSNumber class]] &&
 		[expected isKindOfClass:[NSNumber class]] &&
 		([within isKindOfClass:[NSNumber class]] || (within == nil));
   });
 
-  match(^BOOL{
+  match(^BOOL(id actual) {
 		double actualValue = [actual doubleValue];
 		double expectedValue = [expected doubleValue];
 
@@ -26,7 +26,7 @@ EXPMatcherImplementationBegin(_beCloseToWithin, (id expected, id within)) {
 		}
   });
 
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id actual) {
     if (within) {
       return [NSString stringWithFormat:@"expected %@ to be close to %@ within %@",
               EXPDescribeObject(actual), EXPDescribeObject(expected), EXPDescribeObject(within)];
@@ -36,7 +36,7 @@ EXPMatcherImplementationBegin(_beCloseToWithin, (id expected, id within)) {
     }
   });
 
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id actual) {
     if (within) {
       return [NSString stringWithFormat:@"expected %@ not to be close to %@ within %@",
               EXPDescribeObject(actual), EXPDescribeObject(expected), EXPDescribeObject(within)];

--- a/Expecta/Matchers/EXPMatchers+beFalsy.m
+++ b/Expecta/Matchers/EXPMatchers+beFalsy.m
@@ -2,7 +2,7 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(beFalsy, (void)) {
-  match(^BOOL{
+  match(^BOOL(id actual) {
     if([actual isKindOfClass:[NSNumber class]]) {
       return ![(NSNumber *)actual boolValue];
     } else if([actual isKindOfClass:[NSValue class]]) {
@@ -13,11 +13,11 @@ EXPMatcherImplementationBegin(beFalsy, (void)) {
     return !actual;
   });
 
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id actual) {
     return [NSString stringWithFormat:@"expected: a falsy value, got: %@, which is truthy", EXPDescribeObject(actual)];
   });
 
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id actual) {
     return [NSString stringWithFormat:@"expected: a non-falsy value, got: %@, which is falsy", EXPDescribeObject(actual)];
   });
 }

--- a/Expecta/Matchers/EXPMatchers+beGreaterThan.m
+++ b/Expecta/Matchers/EXPMatchers+beGreaterThan.m
@@ -2,18 +2,18 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(_beGreaterThan, (id expected)) {
-    match(^BOOL{
+    match(^BOOL(id actual) {
         if ([actual respondsToSelector:@selector(compare:)]) {
             return [actual compare:expected] == NSOrderedDescending;
         }
         return NO;
     });
 
-    failureMessageForTo(^NSString *{
+    failureMessageForTo(^NSString *(id actual) {
         return [NSString stringWithFormat:@"expected: %@ to be greater than %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
     });
 
-    failureMessageForNotTo(^NSString *{
+    failureMessageForNotTo(^NSString *(id actual) {
         return [NSString stringWithFormat:@"expected: %@ not to be greater than %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
     });
 }

--- a/Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.m
+++ b/Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.m
@@ -2,18 +2,18 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(_beGreaterThanOrEqualTo, (id expected)) {
-    match(^BOOL{
+    match(^BOOL(id actual) {
         if ([actual respondsToSelector:@selector(compare:)]) {
             return [actual compare:expected] != NSOrderedAscending;
         }
         return NO;
     });
 
-    failureMessageForTo(^NSString *{
+    failureMessageForTo(^NSString *(id actual) {
         return [NSString stringWithFormat:@"expected: %@ to be greater than or equal to %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
     });
 
-    failureMessageForNotTo(^NSString *{
+    failureMessageForNotTo(^NSString *(id actual) {
         return [NSString stringWithFormat:@"expected: %@ not to be greater than or equal to %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
     });
 }

--- a/Expecta/Matchers/EXPMatchers+beIdenticalTo.m
+++ b/Expecta/Matchers/EXPMatchers+beIdenticalTo.m
@@ -2,7 +2,7 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(_beIdenticalTo, (void *expected)) {
-  match(^BOOL{
+  match(^BOOL(id actual) {
     if(actual == expected) {
       return YES;
     } else if([actual isKindOfClass:[NSValue class]] && EXPIsValuePointer((NSValue *)actual)) {
@@ -13,11 +13,11 @@ EXPMatcherImplementationBegin(_beIdenticalTo, (void *expected)) {
     return NO;
   });
 
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id actual) {
     return [NSString stringWithFormat:@"expected: <%p>, got: <%p>", expected, actual];
   });
 
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id actual) {
     return [NSString stringWithFormat:@"expected: not <%p>, got: <%p>", expected, actual];
   });
 }

--- a/Expecta/Matchers/EXPMatchers+beInTheRangeOf.m
+++ b/Expecta/Matchers/EXPMatchers+beInTheRangeOf.m
@@ -2,7 +2,7 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(_beInTheRangeOf, (id expectedLowerBound, id expectedUpperBound)) {
-    match(^BOOL{
+    match(^BOOL(id actual) {
         if ([actual respondsToSelector:@selector(compare:)]) {
             NSComparisonResult compareLowerBound = [expectedLowerBound compare: actual];
             NSComparisonResult compareUpperBound = [expectedUpperBound compare: actual];
@@ -19,11 +19,11 @@ EXPMatcherImplementationBegin(_beInTheRangeOf, (id expectedLowerBound, id expect
         return NO;
     });
 
-    failureMessageForTo(^NSString *{
+    failureMessageForTo(^NSString *(id actual) {
         return [NSString stringWithFormat:@"expected: %@ to be in the range [%@, %@] (inclusive)", EXPDescribeObject(actual), EXPDescribeObject(expectedLowerBound), EXPDescribeObject(expectedUpperBound)];
     });
 
-    failureMessageForNotTo(^NSString *{
+    failureMessageForNotTo(^NSString *(id actual) {
         return [NSString stringWithFormat:@"expected: %@ not to be in the range [%@, %@] (inclusive)", EXPDescribeObject(actual), EXPDescribeObject(expectedLowerBound), EXPDescribeObject(expectedUpperBound)];
     });
 }

--- a/Expecta/Matchers/EXPMatchers+beInstanceOf.m
+++ b/Expecta/Matchers/EXPMatchers+beInstanceOf.m
@@ -1,26 +1,23 @@
 #import "EXPMatchers+beInstanceOf.h"
 
 EXPMatcherImplementationBegin(beInstanceOf, (Class expected)) {
-  BOOL actualIsNil = (actual == nil);
-  BOOL expectedIsNil = (expected == nil);
-
-  prerequisite(^BOOL{
-    return !(actualIsNil || expectedIsNil);
+  prerequisite(^BOOL(id actual) {
+    return actual && expected;
   });
 
-  match(^BOOL{
+  match(^BOOL(id actual) {
     return [actual isMemberOfClass:expected];
   });
 
-  failureMessageForTo(^NSString *{
-    if(actualIsNil) return @"the actual value is nil/null";
-    if(expectedIsNil) return @"the expected value is nil/null";
+  failureMessageForTo(^NSString *(id actual) {
+    if(!actual) return @"the actual value is nil/null";
+    if(!expected) return @"the expected value is nil/null";
     return [NSString stringWithFormat:@"expected: an instance of %@, got: an instance of %@", [expected class], [actual class]];
   });
 
-  failureMessageForNotTo(^NSString *{
-    if(actualIsNil) return @"the actual value is nil/null";
-    if(expectedIsNil) return @"the expected value is nil/null";
+  failureMessageForNotTo(^NSString *(id actual) {
+    if(!actual) return @"the actual value is nil/null";
+    if(!expected) return @"the expected value is nil/null";
     return [NSString stringWithFormat:@"expected: not an instance of %@, got: an instance of %@", [expected class], [actual class]];
   });
 }

--- a/Expecta/Matchers/EXPMatchers+beKindOf.m
+++ b/Expecta/Matchers/EXPMatchers+beKindOf.m
@@ -1,26 +1,23 @@
 #import "EXPMatchers+beKindOf.h"
 
 EXPMatcherImplementationBegin(beKindOf, (Class expected)) {
-  BOOL actualIsNil = (actual == nil);
-  BOOL expectedIsNil = (expected == nil);
-
-  prerequisite(^BOOL{
-    return !(actualIsNil || expectedIsNil);
+  prerequisite(^BOOL(id actual) {
+    return actual && expected;
   });
 
-  match(^BOOL{
+  match(^BOOL(id actual) {
     return [actual isKindOfClass:expected];
   });
 
-  failureMessageForTo(^NSString *{
-    if(actualIsNil) return @"the actual value is nil/null";
-    if(expectedIsNil) return @"the expected value is nil/null";
+  failureMessageForTo(^NSString *(id actual) {
+    if(!actual) return @"the actual value is nil/null";
+    if(!expected) return @"the expected value is nil/null";
     return [NSString stringWithFormat:@"expected: a kind of %@, got: an instance of %@, which is not a kind of %@", [expected class], [actual class], [expected class]];
   });
 
-  failureMessageForNotTo(^NSString *{
-    if(actualIsNil) return @"the actual value is nil/null";
-    if(expectedIsNil) return @"the expected value is nil/null";
+  failureMessageForNotTo(^NSString *(id actual) {
+    if(!actual) return @"the actual value is nil/null";
+    if(!expected) return @"the expected value is nil/null";
     return [NSString stringWithFormat:@"expected: not a kind of %@, got: an instance of %@, which is a kind of %@", [expected class], [actual class], [expected class]];
   });
 }

--- a/Expecta/Matchers/EXPMatchers+beLessThan.m
+++ b/Expecta/Matchers/EXPMatchers+beLessThan.m
@@ -2,18 +2,18 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(_beLessThan, (id expected)) {
-    match(^BOOL{
+    match(^BOOL(id actual) {
         if ([actual respondsToSelector:@selector(compare:)]) {
             return [actual compare:expected] == NSOrderedAscending;
         }
         return NO;
     });
 
-    failureMessageForTo(^NSString *{
+    failureMessageForTo(^NSString *(id actual) {
         return [NSString stringWithFormat:@"expected: %@ to be less than %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
     });
 
-    failureMessageForNotTo(^NSString *{
+    failureMessageForNotTo(^NSString *(id actual) {
         return [NSString stringWithFormat:@"expected: %@ not to be less than %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
     });
 }

--- a/Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.m
+++ b/Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.m
@@ -2,18 +2,18 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(_beLessThanOrEqualTo, (id expected)) {
-    match(^BOOL{
+    match(^BOOL(id actual) {
         if ([actual respondsToSelector:@selector(compare:)]) {
             return [actual compare:expected] != NSOrderedDescending;
         }
         return NO;
     });
 
-    failureMessageForTo(^NSString *{
+    failureMessageForTo(^NSString *(id actual) {
         return [NSString stringWithFormat:@"expected: %@ to be less than or equal to %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
     });
 
-    failureMessageForNotTo(^NSString *{
+    failureMessageForNotTo(^NSString *(id actual) {
         return [NSString stringWithFormat:@"expected: %@ not to be less than or equal to %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
     });
 }

--- a/Expecta/Matchers/EXPMatchers+beNil.m
+++ b/Expecta/Matchers/EXPMatchers+beNil.m
@@ -1,15 +1,15 @@
 #import "EXPMatchers+beNil.h"
 
 EXPMatcherImplementationBegin(beNil, (void)) {
-  match(^BOOL{
-    return actual == nil;
+  match(^BOOL(id actual) {
+    return !actual;
   });
 
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id actual) {
     return [NSString stringWithFormat:@"expected: nil/null, got: %@", EXPDescribeObject(actual)];
   });
 
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id actual) {
     return [NSString stringWithFormat:@"expected: not nil/null, got: %@", EXPDescribeObject(actual)];
   });
 }

--- a/Expecta/Matchers/EXPMatchers+beSubclassOf.m
+++ b/Expecta/Matchers/EXPMatchers+beSubclassOf.m
@@ -5,21 +5,21 @@
 EXPMatcherImplementationBegin(beSubclassOf, (Class expected)) {
   __block BOOL actualIsClass = YES;
 
-  prerequisite(^BOOL {
+  prerequisite(^BOOL(id actual) {
     actualIsClass = class_isMetaClass(object_getClass(actual));
     return actualIsClass;
   });
 
-  match(^BOOL{
+  match(^BOOL(id actual) {
     return [actual isSubclassOfClass:expected];
   });
 
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id actual) {
     if(!actualIsClass) return @"the actual value is not a Class";
     return [NSString stringWithFormat:@"expected: a subclass of %@, got: a class %@, which is not a subclass of %@", [expected class], actual, [expected class]];
   });
 
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id actual) {
     if(!actualIsClass) return @"the actual value is not a Class";
     return [NSString stringWithFormat:@"expected: not a subclass of %@, got: a class %@, which is a subclass of %@", [expected class], actual, [expected class]];
   });

--- a/Expecta/Matchers/EXPMatchers+beSupersetOf.m
+++ b/Expecta/Matchers/EXPMatchers+beSupersetOf.m
@@ -1,27 +1,32 @@
 #import "EXPMatchers+contain.h"
 
 EXPMatcherImplementationBegin(beSupersetOf, (id subset)) {
-  BOOL actualIsCompatible = [actual isKindOfClass:[NSDictionary class]] || [actual respondsToSelector:@selector(containsObject:)];
   BOOL subsetIsNil = (subset == nil);
 
-  // For some instances the isKindOfClass: method returns false, even though
-  // they are both actually dictionaries. e.g. Comparing a NSCFDictionary and a
-  // NSDictionary.
-  // Or in cases when you compare NSMutableArray (which implementation is __NSArrayM:NSMutableArray:NSArray)
-  // and NSArray (which implementation is __NSArrayI:NSArray)
-  BOOL bothAreIdenticalCollectionClasses = ([actual isKindOfClass:[NSDictionary class]] && [subset isKindOfClass:[NSDictionary class]]) ||
-        ([actual isKindOfClass:[NSArray class]] && [subset isKindOfClass:[NSArray class]]) ||
-        ([actual isKindOfClass:[NSSet class]] && [subset isKindOfClass:[NSSet class]]) ||
-        ([actual isKindOfClass:[NSOrderedSet class]] && [subset isKindOfClass:[NSOrderedSet class]]);
+  BOOL(^actualIsCompatible)(id actual) = ^BOOL(id actual) {
+    return [actual isKindOfClass:[NSDictionary class]] || [actual respondsToSelector:@selector(containsObject:)];
+  };
 
-  BOOL classMatches = bothAreIdenticalCollectionClasses || [subset isKindOfClass:[actual class]];
+  BOOL(^classMatches)(id actual) = ^BOOL(id actual) {
+    // For some instances the isKindOfClass: method returns false, even though
+    // they are both actually dictionaries. e.g. Comparing a NSCFDictionary and a
+    // NSDictionary.
+    // Or in cases when you compare NSMutableArray (which implementation is __NSArrayM:NSMutableArray:NSArray)
+    // and NSArray (which implementation is __NSArrayI:NSArray)
+    BOOL bothAreIdenticalCollectionClasses = ([actual isKindOfClass:[NSDictionary class]] && [subset isKindOfClass:[NSDictionary class]]) ||
+          ([actual isKindOfClass:[NSArray class]] && [subset isKindOfClass:[NSArray class]]) ||
+          ([actual isKindOfClass:[NSSet class]] && [subset isKindOfClass:[NSSet class]]) ||
+          ([actual isKindOfClass:[NSOrderedSet class]] && [subset isKindOfClass:[NSOrderedSet class]]);
 
-  prerequisite(^BOOL{
-    return actualIsCompatible && !subsetIsNil && classMatches;
+    return bothAreIdenticalCollectionClasses || [subset isKindOfClass:[actual class]];
+  };
+
+  prerequisite(^BOOL(id actual) {
+    return actualIsCompatible(actual) && !subsetIsNil && classMatches(actual);
   });
 
-  match(^BOOL{
-    if(!actualIsCompatible) return NO;
+  match(^BOOL(id actual) {
+    if(!actualIsCompatible(actual)) return NO;
 
     if([actual isKindOfClass:[NSDictionary class]]) {
       for (id key in subset) {
@@ -39,22 +44,22 @@ EXPMatcherImplementationBegin(beSupersetOf, (id subset)) {
     return YES;
   });
 
-  failureMessageForTo(^NSString *{
-    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSDictionary and does not implement -containsObject:", EXPDescribeObject(actual)];
+  failureMessageForTo(^NSString *(id actual) {
+    if(!actualIsCompatible(actual)) return [NSString stringWithFormat:@"%@ is not an instance of NSDictionary and does not implement -containsObject:", EXPDescribeObject(actual)];
 
     if(subsetIsNil) return @"the expected value is nil/null";
 
-    if(!classMatches) return [NSString stringWithFormat:@"%@ does not match the class of %@", EXPDescribeObject(subset), EXPDescribeObject(actual)];
+    if(!classMatches(actual)) return [NSString stringWithFormat:@"%@ does not match the class of %@", EXPDescribeObject(subset), EXPDescribeObject(actual)];
 
     return [NSString stringWithFormat:@"expected %@ to be a superset of %@", EXPDescribeObject(actual), EXPDescribeObject(subset)];
   });
 
-  failureMessageForNotTo(^NSString *{
-    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSDictionary and does not implement -containsObject:", EXPDescribeObject(actual)];
+  failureMessageForNotTo(^NSString *(id actual) {
+    if(!actualIsCompatible(actual)) return [NSString stringWithFormat:@"%@ is not an instance of NSDictionary and does not implement -containsObject:", EXPDescribeObject(actual)];
 
     if(subsetIsNil) return @"the expected value is nil/null";
 
-    if(!classMatches) return [NSString stringWithFormat:@"%@ does not match the class of %@", EXPDescribeObject(subset), EXPDescribeObject(actual)];
+    if(!classMatches(actual)) return [NSString stringWithFormat:@"%@ does not match the class of %@", EXPDescribeObject(subset), EXPDescribeObject(actual)];
 
     return [NSString stringWithFormat:@"expected %@ not to be a superset of %@", EXPDescribeObject(actual), EXPDescribeObject(subset)];
   });

--- a/Expecta/Matchers/EXPMatchers+beTruthy.m
+++ b/Expecta/Matchers/EXPMatchers+beTruthy.m
@@ -2,7 +2,7 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(beTruthy, (void)) {
-  match(^BOOL{
+  match(^BOOL(id actual) {
     if([actual isKindOfClass:[NSNumber class]]) {
       return !![(NSNumber *)actual boolValue];
     } else if([actual isKindOfClass:[NSValue class]]) {
@@ -13,11 +13,11 @@ EXPMatcherImplementationBegin(beTruthy, (void)) {
     return !!actual;
   });
 
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id actual) {
     return [NSString stringWithFormat:@"expected: a truthy value, got: %@, which is falsy", EXPDescribeObject(actual)];
   });
 
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id actual) {
     return [NSString stringWithFormat:@"expected: a non-truthy value, got: %@, which is truthy", EXPDescribeObject(actual)];
   });
 }

--- a/Expecta/Matchers/EXPMatchers+beginWith.m
+++ b/Expecta/Matchers/EXPMatchers+beginWith.m
@@ -1,18 +1,18 @@
 #import "EXPMatchers+beginWith.h"
 
 EXPMatcherImplementationBegin(beginWith, (id expected)) {
-  BOOL actualIsNil = (actual == nil);
-  BOOL expectedIsNil = (expected == nil);
   //This condition allows the comparison of an immutable string or ordered collection to the mutable type of the same
-  BOOL actualAndExpectedAreCompatible = (([actual isKindOfClass:[NSString class]] && [expected isKindOfClass:[NSString class]])
-                                         || ([actual isKindOfClass:[NSArray class]] && [expected isKindOfClass:[NSArray class]])
-                                         || ([actual isKindOfClass:[NSOrderedSet class]] && [expected isKindOfClass:[NSOrderedSet class]]));
-  
-  prerequisite(^BOOL {
-    return actualAndExpectedAreCompatible;
+  BOOL(^actualAndExpectedAreCompatible)(id actual) = ^BOOL(id actual) {
+    return ([actual isKindOfClass:[NSString class]] && [expected isKindOfClass:[NSString class]])
+        || ([actual isKindOfClass:[NSArray class]] && [expected isKindOfClass:[NSArray class]])
+        || ([actual isKindOfClass:[NSOrderedSet class]] && [expected isKindOfClass:[NSOrderedSet class]]);
+  };
+
+  prerequisite(^BOOL(id actual) {
+    return actualAndExpectedAreCompatible(actual);
   });
   
-  match(^BOOL {
+  match(^BOOL(id actual) {
     if ([actual isKindOfClass:[NSString class]]) {
       return [actual hasPrefix:expected];
     } else if ([actual isKindOfClass:[NSArray class]]) {
@@ -31,17 +31,17 @@ EXPMatcherImplementationBegin(beginWith, (id expected)) {
     }
   });
   
-  failureMessageForTo(^NSString *{
-    if (actualIsNil) return @"the object is nil/null";
-    if (expectedIsNil) return @"the expected value is nil/null";
-    if (!actualAndExpectedAreCompatible) return [NSString stringWithFormat:@"%@ and %@ are not instances of one of %@, %@, or %@", EXPDescribeObject(actual), EXPDescribeObject(expected), [NSString class], [NSArray class], [NSOrderedSet class]];
+  failureMessageForTo(^NSString *(id actual) {
+    if (!actual) return @"the object is nil/null";
+    if (!expected) return @"the expected value is nil/null";
+    if (!actualAndExpectedAreCompatible(actual)) return [NSString stringWithFormat:@"%@ and %@ are not instances of one of %@, %@, or %@", EXPDescribeObject(actual), EXPDescribeObject(expected), [NSString class], [NSArray class], [NSOrderedSet class]];
     return [NSString stringWithFormat:@"expected: %@ to begin with %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
   });
   
-  failureMessageForNotTo(^NSString *{
-    if (actualIsNil) return @"the object is nil/null";
-    if (expectedIsNil) return @"the expected value is nil/null";
-    if (!actualAndExpectedAreCompatible) return [NSString stringWithFormat:@"%@ and %@ are not instances of one of %@, %@, or %@", EXPDescribeObject(actual), EXPDescribeObject(expected), [NSString class], [NSArray class], [NSOrderedSet class]];
+  failureMessageForNotTo(^NSString *(id actual) {
+    if (!actual) return @"the object is nil/null";
+    if (!expected) return @"the expected value is nil/null";
+    if (!actualAndExpectedAreCompatible(actual)) return [NSString stringWithFormat:@"%@ and %@ are not instances of one of %@, %@, or %@", EXPDescribeObject(actual), EXPDescribeObject(expected), [NSString class], [NSArray class], [NSOrderedSet class]];
     
     return [NSString stringWithFormat:@"expected: %@ not to begin with %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
   });

--- a/Expecta/Matchers/EXPMatchers+conformTo.m
+++ b/Expecta/Matchers/EXPMatchers+conformTo.m
@@ -3,28 +3,25 @@
 #import <objc/runtime.h>
 
 EXPMatcherImplementationBegin(conformTo, (Protocol *expected)) {
-    BOOL actualIsNil = (actual == nil);
-    BOOL expectedIsNil = (expected == nil);
-
-    prerequisite(^BOOL{
-        return !(actualIsNil || expectedIsNil);
+    prerequisite(^BOOL(id actual) {
+        return actual && expected;
     });
 
-    match(^BOOL{
+    match(^BOOL(id actual) {
         return [actual conformsToProtocol:expected];
     });
 
-    failureMessageForTo(^NSString *{
-        if(actualIsNil) return @"the object is nil/null";
-        if(expectedIsNil) return @"the protocol is nil/null";
+    failureMessageForTo(^NSString *(id actual) {
+        if(!actual) return @"the object is nil/null";
+        if(!expected) return @"the protocol is nil/null";
 
         NSString *name = NSStringFromProtocol(expected);
         return [NSString stringWithFormat:@"expected: %@ to conform to %@", actual, name];
     });
 
-    failureMessageForNotTo(^NSString *{
-        if(actualIsNil) return @"the object is nil/null";
-        if(expectedIsNil) return @"the protocol is nil/null";
+    failureMessageForNotTo(^NSString *(id actual) {
+        if(!actual) return @"the object is nil/null";
+        if(!expected) return @"the protocol is nil/null";
 
         NSString *name = NSStringFromProtocol(expected);
         return [NSString stringWithFormat:@"expected: %@ not to conform to %@", actual, name];

--- a/Expecta/Matchers/EXPMatchers+contain.m
+++ b/Expecta/Matchers/EXPMatchers+contain.m
@@ -1,15 +1,18 @@
 #import "EXPMatchers+contain.h"
 
 EXPMatcherImplementationBegin(_contain, (id expected)) {
-  BOOL actualIsCompatible = [actual isKindOfClass:[NSString class]] || [actual conformsToProtocol:@protocol(NSFastEnumeration)];
   BOOL expectedIsNil = (expected == nil);
 
-  prerequisite(^BOOL{
-    return actualIsCompatible && !expectedIsNil;
+  BOOL(^actualIsCompatible)(id actual) = ^BOOL(id actual) {
+    return [actual isKindOfClass:[NSString class]] || [actual conformsToProtocol:@protocol(NSFastEnumeration)];
+  };
+
+  prerequisite(^BOOL(id actual) {
+    return actualIsCompatible(actual) && !expectedIsNil;
   });
 
-  match(^BOOL{
-    if(actualIsCompatible) {
+  match(^BOOL(id actual) {
+    if(actualIsCompatible(actual)) {
       if([actual isKindOfClass:[NSString class]]) {
         return [(NSString *)actual rangeOfString:[expected description]].location != NSNotFound;
       } else {
@@ -23,14 +26,14 @@ EXPMatcherImplementationBegin(_contain, (id expected)) {
     return NO;
   });
 
-  failureMessageForTo(^NSString *{
-    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSString or NSFastEnumeration", EXPDescribeObject(actual)];
+  failureMessageForTo(^NSString *(id actual) {
+    if(!actualIsCompatible(actual)) return [NSString stringWithFormat:@"%@ is not an instance of NSString or NSFastEnumeration", EXPDescribeObject(actual)];
     if(expectedIsNil) return @"the expected value is nil/null";
     return [NSString stringWithFormat:@"expected %@ to contain %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
   });
 
-  failureMessageForNotTo(^NSString *{
-    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSString or NSFastEnumeration", EXPDescribeObject(actual)];
+  failureMessageForNotTo(^NSString *(id actual) {
+    if(!actualIsCompatible(actual)) return [NSString stringWithFormat:@"%@ is not an instance of NSString or NSFastEnumeration", EXPDescribeObject(actual)];
     if(expectedIsNil) return @"the expected value is nil/null";
     return [NSString stringWithFormat:@"expected %@ not to contain %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
   });

--- a/Expecta/Matchers/EXPMatchers+endWith.m
+++ b/Expecta/Matchers/EXPMatchers+endWith.m
@@ -1,18 +1,18 @@
 #import "EXPMatchers+endWith.h"
 
 EXPMatcherImplementationBegin(endWith, (id expected)) {
-  BOOL actualIsNil = (actual == nil);
-  BOOL expectedIsNil = (expected == nil);
   //This condition allows the comparison of an immutable string or ordered collection to the mutable type of the same
-  BOOL actualAndExpectedAreCompatible = (([actual isKindOfClass:[NSString class]] && [expected isKindOfClass:[NSString class]])
-                                         || ([actual isKindOfClass:[NSArray class]] && [expected isKindOfClass:[NSArray class]])
-                                         || ([actual isKindOfClass:[NSOrderedSet class]] && [expected isKindOfClass:[NSOrderedSet class]]));
+  BOOL(^actualAndExpectedAreCompatible)(id actual) = ^BOOL(id actual) {
+    return ([actual isKindOfClass:[NSString class]] && [expected isKindOfClass:[NSString class]])
+        || ([actual isKindOfClass:[NSArray class]] && [expected isKindOfClass:[NSArray class]])
+        || ([actual isKindOfClass:[NSOrderedSet class]] && [expected isKindOfClass:[NSOrderedSet class]]);
+  };
   
-  prerequisite(^BOOL {
-    return actualAndExpectedAreCompatible;
+  prerequisite(^BOOL(id actual) {
+    return actualAndExpectedAreCompatible(actual);
   });
   
-  match(^BOOL {
+  match(^BOOL(id actual) {
     if ([actual isKindOfClass:[NSString class]]) {
       return [actual hasSuffix:expected];
     } else if ([actual isKindOfClass:[NSArray class]]) {
@@ -31,17 +31,17 @@ EXPMatcherImplementationBegin(endWith, (id expected)) {
     }
   });
   
-  failureMessageForTo(^NSString *{
-    if (actualIsNil) return @"the object is nil/null";
-    if (expectedIsNil) return @"the expected value is nil/null";
-    if (!actualAndExpectedAreCompatible) return [NSString stringWithFormat:@"%@ and %@ are not instances of one of %@, %@, or %@", EXPDescribeObject(actual), EXPDescribeObject(expected), [NSString class], [NSArray class], [NSOrderedSet class]];
+  failureMessageForTo(^NSString *(id actual) {
+    if (!actual) return @"the object is nil/null";
+    if (!expected) return @"the expected value is nil/null";
+    if (!actualAndExpectedAreCompatible(actual)) return [NSString stringWithFormat:@"%@ and %@ are not instances of one of %@, %@, or %@", EXPDescribeObject(actual), EXPDescribeObject(expected), [NSString class], [NSArray class], [NSOrderedSet class]];
     return [NSString stringWithFormat:@"expected: %@ to end with %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
   });
   
-  failureMessageForNotTo(^NSString *{
-    if (actualIsNil) return @"the object is nil/null";
-    if (expectedIsNil) return @"the expected value is nil/null";
-    if (!actualAndExpectedAreCompatible) return [NSString stringWithFormat:@"%@ and %@ are not instances of one of %@, %@, or %@", EXPDescribeObject(actual), EXPDescribeObject(expected), [NSString class], [NSArray class], [NSOrderedSet class]];
+  failureMessageForNotTo(^NSString *(id actual) {
+    if (!actual) return @"the object is nil/null";
+    if (!expected) return @"the expected value is nil/null";
+    if (!actualAndExpectedAreCompatible(actual)) return [NSString stringWithFormat:@"%@ and %@ are not instances of one of %@, %@, or %@", EXPDescribeObject(actual), EXPDescribeObject(expected), [NSString class], [NSArray class], [NSOrderedSet class]];
     
     return [NSString stringWithFormat:@"expected: %@ not to end with %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
   });

--- a/Expecta/Matchers/EXPMatchers+equal.m
+++ b/Expecta/Matchers/EXPMatchers+equal.m
@@ -2,7 +2,7 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(_equal, (id expected)) {
-  match(^BOOL{
+  match(^BOOL(id actual) {
     if((actual == expected) || [actual isEqual:expected]) {
       return YES;
     } else if([actual isKindOfClass:[NSNumber class]] && [expected isKindOfClass:[NSNumber class]]) {
@@ -20,7 +20,7 @@ EXPMatcherImplementationBegin(_equal, (id expected)) {
     return NO;
   });
 
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id actual) {
     NSString *expectedDescription = EXPDescribeObject(expected);
     NSString *actualDescription = EXPDescribeObject(actual);
 
@@ -31,7 +31,7 @@ EXPMatcherImplementationBegin(_equal, (id expected)) {
     }
   });
 
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id actual) {
     return [NSString stringWithFormat:@"expected: not %@, got: %@", EXPDescribeObject(expected), EXPDescribeObject(actual)];
   });
 }

--- a/Expecta/Matchers/EXPMatchers+haveCountOf.m
+++ b/Expecta/Matchers/EXPMatchers+haveCountOf.m
@@ -1,35 +1,40 @@
 #import "EXPMatchers+haveCountOf.h"
 
 EXPMatcherImplementationBegin(haveCountOf, (NSUInteger expected)) {
-  BOOL actualIsStringy = [actual isKindOfClass:[NSString class]] || [actual isKindOfClass:[NSAttributedString class]];
-  BOOL actualIsCompatible = actualIsStringy || [actual respondsToSelector:@selector(count)];
+  BOOL(^actualIsStringy)(id actual) = ^BOOL(id actual) {
+    return [actual isKindOfClass:[NSString class]] || [actual isKindOfClass:[NSAttributedString class]];
+  };
 
-  prerequisite(^BOOL{
-    return actualIsCompatible;
+  BOOL(^actualIsCompatible)(id actual) = ^BOOL(id actual) {
+    return actualIsStringy(actual) || [actual respondsToSelector:@selector(count)];
+  };
+
+  prerequisite(^BOOL(id actual) {
+    return actualIsCompatible(actual);
   });
 
   NSUInteger (^count)(id) = ^(id actual) {
-    if(actualIsStringy) {
+    if(actualIsStringy(actual)) {
       return [actual length];
   } else {
       return [actual count];
     }
   };
 
-  match(^BOOL{
-    if(actualIsCompatible) {
+  match(^BOOL(id actual) {
+    if (actualIsCompatible(actual)) {
       return count(actual) == expected;
     }
     return NO;
   });
 
-  failureMessageForTo(^NSString *{
-    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSString, NSAttributedString, NSArray, NSSet, NSOrderedSet, or NSDictionary", EXPDescribeObject(actual)];
+  failureMessageForTo(^NSString *(id actual) {
+    if(!actualIsCompatible(actual)) return [NSString stringWithFormat:@"%@ is not an instance of NSString, NSAttributedString, NSArray, NSSet, NSOrderedSet, or NSDictionary", EXPDescribeObject(actual)];
     return [NSString stringWithFormat:@"expected %@ to have a count of %zi but got %zi", EXPDescribeObject(actual), expected, count(actual)];
   });
 
-  failureMessageForNotTo(^NSString *{
-    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSString, NSAttributedString, NSArray, NSSet, NSOrderedSet, or NSDictionary", EXPDescribeObject(actual)];
+  failureMessageForNotTo(^NSString *(id actual) {
+    if(!actualIsCompatible(actual)) return [NSString stringWithFormat:@"%@ is not an instance of NSString, NSAttributedString, NSArray, NSSet, NSOrderedSet, or NSDictionary", EXPDescribeObject(actual)];
     return [NSString stringWithFormat:@"expected %@ not to have a count of %zi", EXPDescribeObject(actual), expected];
   });
 }

--- a/Expecta/Matchers/EXPMatchers+match.m
+++ b/Expecta/Matchers/EXPMatchers+match.m
@@ -2,35 +2,33 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(match, (NSString *expected)) {
-  BOOL actualIsNil = (actual == nil);
-  BOOL expectedIsNil = (expected == nil);
-  
   __block NSRegularExpression *regex = nil;
   __block NSError *regexError = nil;
   
-  prerequisite (^BOOL {
-    BOOL nilInput = (actualIsNil || expectedIsNil);
-    if (!nilInput) {
-      regex = [NSRegularExpression regularExpressionWithPattern:expected options:0 error:&regexError];
+  prerequisite(^BOOL(id actual) {
+    if (!actual || !expected) {
+      return NO;
     }
-    return !nilInput && regex;
+
+    regex = [NSRegularExpression regularExpressionWithPattern:expected options:0 error:&regexError];
+    return regex != nil;
   });
   
-  match(^BOOL {
+  match(^BOOL(id actual) {
     NSRange range = [regex rangeOfFirstMatchInString:actual options:0 range:NSMakeRange(0, [actual length])];
     return !NSEqualRanges(range, NSMakeRange(NSNotFound, 0));
   });
   
-  failureMessageForTo(^NSString *{
-    if (actualIsNil) return @"the object is nil/null";
-    if (expectedIsNil) return @"the expression is nil/null";
+  failureMessageForTo(^NSString *(id actual) {
+    if (!actual) return @"the object is nil/null";
+    if (!expected) return @"the expression is nil/null";
     if (regexError) return [NSString stringWithFormat:@"unable to create regular expression from given parameter: %@", [regexError localizedDescription]];
     return [NSString stringWithFormat:@"expected: %@ to match to %@", EXPDescribeObject(actual), expected];
   });
   
-  failureMessageForNotTo(^NSString *{
-    if (actualIsNil) return @"the object is nil/null";
-    if (expectedIsNil) return @"the expression is nil/null";
+  failureMessageForNotTo(^NSString *(id actual) {
+    if (!actual) return @"the object is nil/null";
+    if (!expected) return @"the expression is nil/null";
     if (regexError) return [NSString stringWithFormat:@"unable to create regular expression from given parameter: %@", [regexError localizedDescription]];
     return [NSString stringWithFormat:@"expected: %@ not to match to %@", EXPDescribeObject(actual), expected];
   });

--- a/Expecta/Matchers/EXPMatchers+postNotification.m
+++ b/Expecta/Matchers/EXPMatchers+postNotification.m
@@ -24,8 +24,6 @@
 @end
 
 EXPMatcherImplementationBegin(postNotification, (id expected)){
-  BOOL actualIsNil = (actual == nil);
-  BOOL expectedIsNil = (expected == nil);
   BOOL isNotification = [expected isKindOfClass:[NSNotification class]];
   BOOL isName = [expected isKindOfClass:[NSString class]];
 
@@ -33,9 +31,9 @@ EXPMatcherImplementationBegin(postNotification, (id expected)){
   __block BOOL expectedNotificationOccurred = NO;
   __block id observer;
 
-  prerequisite(^BOOL{
+  prerequisite(^BOOL(id actual) {
     expectedNotificationOccurred = NO;
-    if (actualIsNil || expectedIsNil) return NO;
+    if (!actual || !expected) return NO;
     if (isNotification) {
       expectedName = [expected name];
     }else if(isName) {
@@ -55,29 +53,29 @@ EXPMatcherImplementationBegin(postNotification, (id expected)){
     return YES;
   });
 
-  match(^BOOL{
+  match(^BOOL(id __unused actual) {
     if(expectedNotificationOccurred) {
       [[NSNotificationCenter defaultCenter] removeObserver:observer];
     }
     return expectedNotificationOccurred;
   });
 
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id actual) {
     if (observer) {
       [[NSNotificationCenter defaultCenter] removeObserver:observer];
     }
-    if(actualIsNil) return @"the actual value is nil/null";
-    if(expectedIsNil) return @"the expected value is nil/null";
+    if(!actual) return @"the actual value is nil/null";
+    if(!expected) return @"the expected value is nil/null";
     if(!(isNotification || isName)) return @"the actual value is not a notification or string";
     return [NSString stringWithFormat:@"expected: %@, got: none",expectedName];
   });
 
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id actual) {
     if (observer) {
       [[NSNotificationCenter defaultCenter] removeObserver:observer];
     }
-    if(actualIsNil) return @"the actual value is nil/null";
-    if(expectedIsNil) return @"the expected value is nil/null";
+    if(!actual) return @"the actual value is nil/null";
+    if(!expected) return @"the expected value is nil/null";
     if(!(isNotification || isName)) return @"the actual value is not a notification or string";
     return [NSString stringWithFormat:@"expected: none, got: %@", expectedName];
   });

--- a/Expecta/Matchers/EXPMatchers+raise.m
+++ b/Expecta/Matchers/EXPMatchers+raise.m
@@ -4,7 +4,7 @@
 EXPMatcherImplementationBegin(raise, (NSString *expectedExceptionName)) {
   __block NSException *exceptionCaught = nil;
 
-  match(^BOOL{
+  match(^BOOL(id actual) {
     BOOL expectedExceptionCaught = NO;
     @try {
       ((EXPBasicBlock)actual)();
@@ -15,13 +15,13 @@ EXPMatcherImplementationBegin(raise, (NSString *expectedExceptionName)) {
     return expectedExceptionCaught;
   });
 
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id __unused actual) {
     return [NSString stringWithFormat:@"expected: %@, got: %@",
             expectedExceptionName ? expectedExceptionName : @"any exception",
             exceptionCaught ? [exceptionCaught name] : @"no exception"];
   });
 
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id __unused actual) {
     return [NSString stringWithFormat:@"expected: %@, got: %@",
             expectedExceptionName ? [NSString stringWithFormat:@"not %@", expectedExceptionName] : @"no exception",
             exceptionCaught ? [exceptionCaught name] : @"no exception"];

--- a/Expecta/Matchers/EXPMatchers+raiseWithReason.m
+++ b/Expecta/Matchers/EXPMatchers+raiseWithReason.m
@@ -4,7 +4,7 @@
 EXPMatcherImplementationBegin(raiseWithReason, (NSString *expectedExceptionName, NSString *expectedReason)) {
     __block NSException *exceptionCaught = nil;
     
-    match(^BOOL{
+    match(^BOOL(id actual) {
         BOOL expectedExceptionCaught = NO;
         @try {
             ((EXPBasicBlock)actual)();
@@ -16,7 +16,7 @@ EXPMatcherImplementationBegin(raiseWithReason, (NSString *expectedExceptionName,
         return expectedExceptionCaught;
     });
     
-    failureMessageForTo(^NSString *{
+    failureMessageForTo(^NSString *(id __unused actual) {
         return [NSString stringWithFormat:@"expected: %@ (%@), got: %@ (%@)",
                 expectedExceptionName ?: @"any exception",
                 expectedReason ?: @"any reason",
@@ -24,7 +24,7 @@ EXPMatcherImplementationBegin(raiseWithReason, (NSString *expectedExceptionName,
                 exceptionCaught ? [exceptionCaught reason] : @""];
     });
     
-    failureMessageForNotTo(^NSString *{
+    failureMessageForNotTo(^NSString *(id __unused actual) {
         return [NSString stringWithFormat:@"expected: %@ (%@), got: %@ (%@)",
                 expectedExceptionName ? [NSString stringWithFormat:@"not %@", expectedExceptionName] : @"no exception",
                 expectedReason ? [NSString stringWithFormat:@"not '%@'", expectedReason] : @"no reason",

--- a/Expecta/Matchers/EXPMatchers+respondTo.m
+++ b/Expecta/Matchers/EXPMatchers+respondTo.m
@@ -2,26 +2,23 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(respondTo, (SEL expected)) {
-  BOOL actualIsNil = (actual == nil);
-  BOOL expectedIsNull = (expected == NULL);
-
-  prerequisite (^BOOL {
-    return !(actualIsNil || expectedIsNull);
+  prerequisite(^BOOL(id actual) {
+    return actual && expected;
   });
 
-  match(^BOOL {
+  match(^BOOL(id actual) {
     return [actual respondsToSelector:expected];
   });
 
-  failureMessageForTo(^NSString *{
-    if (actualIsNil) return @"the object is nil/null";
-    if (expectedIsNull) return @"the selector is null";
+  failureMessageForTo(^NSString *(id actual) {
+    if (!actual) return @"the object is nil/null";
+    if (!expected) return @"the selector is null";
     return [NSString stringWithFormat:@"expected: %@ to respond to %@", EXPDescribeObject(actual), NSStringFromSelector(expected)];
   });
 
-  failureMessageForNotTo(^NSString *{
-    if (actualIsNil) return @"the object is nil/null";
-    if (expectedIsNull) return @"the selector is null";
+  failureMessageForNotTo(^NSString *(id actual) {
+    if (!actual) return @"the object is nil/null";
+    if (!expected) return @"the selector is null";
     return [NSString stringWithFormat:@"expected: %@ not to respond to %@", EXPDescribeObject(actual), NSStringFromSelector(expected)];
   });
 }

--- a/README.md
+++ b/README.md
@@ -203,26 +203,23 @@ EXPMatcherInterface(beKindOf, (Class expected));
 #import "EXPMatchers+beKindOf.h"
 
 EXPMatcherImplementationBegin(beKindOf, (Class expected)) {
-  BOOL actualIsNil = (actual == nil);
-  BOOL expectedIsNil = (expected == nil);
-
-  prerequisite(^BOOL {
-    return !(actualIsNil || expectedIsNil);
+  prerequisite(^BOO(id actual) {
+    return actual && expected;
     // Return `NO` if matcher should fail whether or not the result is inverted
     // using `.Not`.
   });
 
-  match(^BOOL {
+  match(^BOOL(id actual) {
     return [actual isKindOfClass:expected];
     // Return `YES` if the matcher should pass, `NO` if it should not.
     // The actual value/object is passed as `actual`.
     // Please note that primitive values will be wrapped in NSNumber/NSValue.
   });
 
-  failureMessageForTo(^NSString * {
-    if (actualIsNil)
+  failureMessageForTo(^NSString *(id actual) {
+    if (!actual)
       return @"the actual value is nil/null";
-    if (expectedIsNil)
+    if (!expected)
       return @"the expected value is nil/null";
     return [NSString
         stringWithFormat:@"expected: a kind of %@, "
@@ -231,10 +228,10 @@ EXPMatcherImplementationBegin(beKindOf, (Class expected)) {
     // Return the message to be displayed when the match function returns `YES`.
   });
 
-  failureMessageForNotTo(^NSString * {
-    if (actualIsNil)
+  failureMessageForNotTo(^NSString *(id actual) {
+    if (!actual)
       return @"the actual value is nil/null";
-    if (expectedIsNil)
+    if (!expected)
       return @"the expected value is nil/null";
     return [NSString
         stringWithFormat:@"expected: not a kind of %@, "

--- a/Tests/MiscTest.m
+++ b/Tests/MiscTest.m
@@ -20,12 +20,4 @@
   expect(EXPDescribeObject(dict)).equal(@"{foo = bar;}");
 }
 
-- (void)test_EXPObjectifyCopiesObjectsWithBlockType
-{
-    id original = [[NSMutableArray alloc] init];
-    id copy = _EXPObjectify(@encode(EXPBasicBlock), original);
-    
-    expect(original == copy).to.beFalsy();
-}
-
 @end


### PR DESCRIPTION
The current implementation of Expecta passes `actual` as a captured
variable to the `prerequisite`, `match`, `failureMessageForTo` and
`failureMessageForNotTo` blocks, and overwrites `actual` via a pointer
to an ObjC object.

From experimentation, it seems that matchers that are written in ARC do
not work well with this method - if `will` or `after` is used, `actual`
will not get updated on each iteration of the matcher. Additionally, we
suspect that this implementation may create memory leaks, as the object
pointed to is not being explicitly `release`ed.

This commit makes the code more straightforward and clean, by passing
`actual` to the aforementioned blocks, and removing it from the capture
list of these blocks.

Since this is an Expecta API change, it requires changes across all the
matchers.