### PR TITLE
NSArray+Difference: handle nil and non-array arguments.

### DIFF
--- a/Expecta/EXPDifference.h
+++ b/Expecta/EXPDifference.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///  @"string:",
 ///  @"  Expected: something",
 ///  @"    Actual: something else"]
-- (NSArray<NSString *> *)differenceFrom:(id)object;
+- (NSArray<NSString *> *)differenceFrom:(nullable id)object;
 
 @end
 

--- a/Expecta/NSArray+Difference.m
+++ b/Expecta/NSArray+Difference.m
@@ -39,9 +39,18 @@ API_AVAILABLE(ios(13.0))
 
 @implementation NSArray (Difference)
 
-- (NSArray<NSString *> *)differenceFrom:(id)object
+- (NSArray<NSString *> *)differenceFrom:(nullable id)object
     API_AVAILABLE(ios(13.0)) {
-  assert([object isKindOfClass:NSArray.class]);
+  if (!object) {
+    return @[@"Expected: NSArray, got: nil"];
+  }
+
+  if (![object isKindOfClass:[NSArray class]]) {
+    return @[
+      [NSString stringWithFormat:@"Expected: NSArray, got: %@", NSStringFromClass([object class])]
+    ];
+  }
+
   NSArray *expected = self;
   NSArray *actual = (NSArray *)object;
 

--- a/Tests/Matchers/EXPMatchers+equalTest.m
+++ b/Tests/Matchers/EXPMatchers+equalTest.m
@@ -275,4 +275,24 @@ typedef struct SomeFloatPairPair {
   assertFail(test_expect((@[@1, @2, @3, @4, @5])).equal(@[@3, @6, @1, @9, @4]), [lines componentsJoinedByString:@"\n"]);
 }
 
+- (void)test_equal_array_difference_from_nonarray {
+  NSArray *lines = @[
+    @"Expected: NSArray, got: __NSCFNumber",
+    @"",
+    @"expected: (1, 2), got: 8"
+  ];
+
+  assertFail(test_expect((@8)).equal(@[@1, @2]), [lines componentsJoinedByString:@"\n"]);
+}
+
+- (void)test_equal_array_difference_from_nil {
+  NSArray *lines = @[
+    @"Expected: NSArray, got: nil",
+    @"",
+    @"expected: (1, 2), got: nil/null"
+  ];
+
+  assertFail(test_expect((nil)).equal(@[@1, @2]), [lines componentsJoinedByString:@"\n"]);
+}
+
 @end

--- a/Tests/NSArray+DifferenceTest.m
+++ b/Tests/NSArray+DifferenceTest.m
@@ -15,7 +15,7 @@
   return NO;
 }
 
-- (nonnull NSArray<NSString *> *)differenceFrom:(id)object {
+- (nonnull NSArray<NSString *> *)differenceFrom:(nullable id)object {
   return @[@"wink-wink"];
 }
 


### PR DESCRIPTION
Raising from differenceFrom has negative effect of disrupting tests and
makes getting to the mismatch harder. Therefore returning a descriptive
message for nil and non-array arguments.
